### PR TITLE
Expose more of the TCN native api as JS classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,12 @@ In case you are using a different version of Node or an unusual system architect
 The API of the Rust [tcn crate](https://docs.rs/tcn/0.4.1/tcn/) is wrapped in a native Node addon and can be used in much the same way as if you were using that crate in Rust code:
 
 ```js
-const { ReportAuthorizationKey, MemoType } = require("../src/index").native;
+const { ReportAuthorizationKey, MemoType } = require("tcn-node").native;
 const assert = require("assert");
 
 // Generate a report authorization key.  This key represents the capability
 // to publish a report about a collection of derived temporary contact numbers.
-let rak = new native.ReportAuthorizationKey();
+let rak = new ReportAuthorizationKey();
 
 // Use the temporary contact key ratchet mechanism to compute a list
 // of temporary contact numbers.
@@ -55,7 +55,7 @@ for (let i = 0; i < 100; i++) {
 
 // Prepare a report about a subset of the temporary contact numbers.
 let signed_report = rak.create_report(
-  native.MemoType.CoEpiV1, // The memo type
+  MemoType.CoEpiV1, // The memo type
   Buffer.from("symptom data"), // The memo data
   20, // Index of the first TCN to disclose
   90 // Index of the last TCN to check
@@ -76,7 +76,7 @@ assert.deepEqual(recomputed_tcns, tcns.slice(20 - 1, 90 - 1));
 The JS API is a work in progress and currently consists of a few example functions only:
 
 ```js
-import { tcnExample, signedReportExample, validateReport } from "tcn-node";
+const { tcnExample, signedReportExample, validateReport } = require("tcn-node");
 
 console.log(tcnExample()); // => "symptom data"
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,49 @@ In case you are using a different version of Node or an unusual system architect
 
 ## Usage
 
+### Using the TCN native module directly
+
+The API of the Rust [tcn crate](https://docs.rs/tcn/0.4.1/tcn/) is wrapped in a native Node addon and can be used in much the same way as if you were using that crate in Rust code:
+
+```js
+const { ReportAuthorizationKey, MemoType } = require("../src/index").native;
+const assert = require("assert");
+
+// Generate a report authorization key.  This key represents the capability
+// to publish a report about a collection of derived temporary contact numbers.
+let rak = new native.ReportAuthorizationKey();
+
+// Use the temporary contact key ratchet mechanism to compute a list
+// of temporary contact numbers.
+let tck = rak.initial_temporary_contact_key(); // tck <- tck_1
+let tcns = [];
+for (let i = 0; i < 100; i++) {
+  tcns.push(tck.temporary_contact_number());
+  tck = tck.ratchet();
+}
+
+// Prepare a report about a subset of the temporary contact numbers.
+let signed_report = rak.create_report(
+  native.MemoType.CoEpiV1, // The memo type
+  Buffer.from("symptom data"), // The memo data
+  20, // Index of the first TCN to disclose
+  90 // Index of the last TCN to check
+);
+
+// Verify the source integrity of the report...
+let report = signed_report.verify();
+// ...allowing the disclosed TCNs to be recomputed.
+let recomputed_tcns = report.temporary_contact_numbers();
+
+// Check that the recomputed TCNs match the originals.
+// The slice is offset by 1 because tcn_0 is not included.
+assert.deepEqual(recomputed_tcns, tcns.slice(20 - 1, 90 - 1));
+```
+
+### JavaScript API
+
+The JS API is a work in progress and currently consists of a few example functions only:
+
 ```js
 import { tcnExample, signedReportExample, validateReport } from "tcn-node";
 

--- a/native/Cargo.lock
+++ b/native/Cargo.lock
@@ -160,6 +160,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8b7a7c0c47db5545ed3fef7468ee7bb5b74691498139e4b3f6a20685dc6dd8e"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +397,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c691c0e608126e00913e33f0ccf3727d5fc84573623b8d65b2df340b5201783"
 
 [[package]]
+name = "ryu"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3d612bc64430efeb3f7ee6ef26d590dce0c43249217bddc62112540c7941e1"
+
+[[package]]
 name = "semver"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +438,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7894c8ed05b7a3a279aeb79025fdec1d3158080b75b98a08faf2806bb799edd"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -457,7 +480,7 @@ dependencies = [
 [[package]]
 name = "tcn"
 version = "0.4.1"
-source = "git+https://github.com/miridius/TCN?branch=serde#11348abe0d240a1c3d1f3e35eacc6741213a1d0f"
+source = "git+https://github.com/miridius/TCN?branch=serde#75f60431b5490ae0b94d540d04d8a6684cd167ce"
 dependencies = [
  "byteorder",
  "ed25519-zebra",
@@ -471,11 +494,13 @@ dependencies = [
 name = "tcn-node"
 version = "0.3.0"
 dependencies = [
+ "ed25519-zebra",
  "neon",
  "neon-build",
  "neon-serde",
  "rand",
  "serde",
+ "serde_json",
  "tcn",
 ]
 

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -20,3 +20,5 @@ neon-serde = { git = "https://github.com/miridius/neon-serde", branch = "use-neo
 rand = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 tcn = { git = "https://github.com/miridius/TCN", branch = "serde" }
+ed25519-zebra = "0.2.2"
+serde_json = "1.0"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,49 @@
-const native = require("../native");
+export const native = require("../native");
 
-export const tcnExample = native.tcnExample;
+export const tcnExample = () => {
+  const assert = require("assert");
+
+  // Generate a report authorization key.  This key represents the capability
+  // to publish a report about a collection of derived temporary contact numbers.
+  let rak = new native.ReportAuthorizationKey();
+
+  // Use the temporary contact key ratchet mechanism to compute a list
+  // of temporary contact numbers.
+  let tck = rak.initial_temporary_contact_key(); // tck <- tck_1
+  let tcns = [];
+  for (let i = 0; i < 100; i++) {
+    tcns.push(tck.temporary_contact_number());
+    tck = tck.ratchet();
+  }
+
+  // Prepare a report about a subset of the temporary contact numbers.
+  let signed_report = rak.create_report(
+    native.MemoType.CoEpiV1, // The memo type
+    Buffer.from("symptom data"), // The memo data
+    20, // Index of the first TCN to disclose
+    90 // Index of the last TCN to check
+  );
+
+  // Verify the source integrity of the report...
+  let report = signed_report.verify();
+  // ...allowing the disclosed TCNs to be recomputed.
+  let recomputed_tcns = report.temporary_contact_numbers();
+
+  // Check that the recomputed TCNs match the originals.
+  // The slice is offset by 1 because tcn_0 is not included.
+  assert.deepEqual(recomputed_tcns, tcns.slice(20 - 1, 90 - 1));
+
+  // Read the memo data from the report
+  return Buffer.from(report.toObject().memo_data).toString();
+};
+
 // also include the old function name so as to not break users of older versions of this library
 export const tcn_example = tcnExample;
 
-export const signedReportExample = native.signedReportExample;
+export const signedReportExample = () =>
+  new native.ReportAuthorizationKey()
+    .create_report(native.MemoType.CoEpiV1, Buffer.from("symptom data"), 20, 90)
+    .toObject();
 
 export const validateReport = (r: any) => {
   // fix for neon-serde deserialization issue - rvk must be an array in an array
@@ -17,5 +56,12 @@ export const validateReport = (r: any) => {
   ) {
     r.report.rvk = [r.report.rvk];
   }
-  return native.validateReport(r);
+
+  let signedReport = new native.SignedReport(r);
+  try {
+    signedReport.verify();
+    return true;
+  } catch (error) {
+    return false;
+  }
 };

--- a/test/native.test.ts
+++ b/test/native.test.ts
@@ -1,4 +1,4 @@
-const { ReportAuthorizationKey, MemoType } = require("../src/index").native;
+const { ReportAuthorizationKey, MemoType } = require("../native");
 
 describe("TCN native module", () => {
   // Below is taken directly from the Rust example at https://docs.rs/tcn/0.4.1/tcn/

--- a/test/native.test.ts
+++ b/test/native.test.ts
@@ -1,0 +1,38 @@
+const { ReportAuthorizationKey, MemoType } = require("../src/index").native;
+
+describe("TCN native module", () => {
+  // Below is taken directly from the Rust example at https://docs.rs/tcn/0.4.1/tcn/
+  // with minimal modifications to make it work in JS
+  it("should support the example usage from the TCN docs", () => {
+    // Generate a report authorization key.  This key represents the capability
+    // to publish a report about a collection of derived temporary contact numbers.
+    let rak = new ReportAuthorizationKey();
+
+    // Use the temporary contact key ratchet mechanism to compute a list
+    // of temporary contact numbers.
+    let tck = rak.initial_temporary_contact_key(); // tck <- tck_1
+    let tcns = Array.from({ length: 100 }, () => {
+      let tcn = tck.temporary_contact_number();
+      tck = tck.ratchet();
+      return tcn;
+    });
+    expect(tcns).toHaveLength(100);
+
+    // Prepare a report about a subset of the temporary contact numbers.
+    let signed_report = rak.create_report(
+      MemoType.CoEpiV1, // The memo type
+      Buffer.from("symptom data"), // The memo data
+      20, // Index of the first TCN to disclose
+      90 // Index of the last TCN to check
+    );
+
+    // Verify the source integrity of the report...
+    let report = signed_report.verify();
+    // ...allowing the disclosed TCNs to be recomputed.
+    let recomputed_tcns = report.temporary_contact_numbers();
+
+    // Check that the recomputed TCNs match the originals.
+    // The slice is offset by 1 because tcn_0 is not included.
+    expect(recomputed_tcns).toEqual(tcns.slice(20 - 1, 90 - 1));
+  });
+});


### PR DESCRIPTION
Many of the Rust [tcn crate](https://docs.rs/tcn/0.4.1/tcn/) structs are now exposed via the native addon as JS classes. The instantiated JS objects hold handles to Rust structs under the hood so that we can call the native API's methods on them.

We can now run the the tcn example flow using javascript:

```js
const { ReportAuthorizationKey, MemoType } = require("tcn-node").native;
const assert = require("assert");

// Generate a report authorization key.  This key represents the capability
// to publish a report about a collection of derived temporary contact numbers.
let rak = new ReportAuthorizationKey();

// Use the temporary contact key ratchet mechanism to compute a list
// of temporary contact numbers.
let tck = rak.initial_temporary_contact_key(); // tck <- tck_1
let tcns = [];
for (let i = 0; i < 100; i++) {
  tcns.push(tck.temporary_contact_number());
  tck = tck.ratchet();
}

// Prepare a report about a subset of the temporary contact numbers.
let signed_report = rak.create_report(
  MemoType.CoEpiV1, // The memo type
  Buffer.from("symptom data"), // The memo data
  20, // Index of the first TCN to disclose
  90 // Index of the last TCN to check
);

// Verify the source integrity of the report...
let report = signed_report.verify();
// ...allowing the disclosed TCNs to be recomputed.
let recomputed_tcns = report.temporary_contact_numbers();

// Check that the recomputed TCNs match the originals.
// The slice is offset by 1 because tcn_0 is not included.
assert.deepEqual(recomputed_tcns, tcns.slice(20 - 1, 90 - 1));
```